### PR TITLE
Increase output_limit

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -1,6 +1,7 @@
 locals {
   config = <<EOF
 [[runners]]
+  output_limit = 10000000
 %{if var.cache.type == "local"~}
   cache_dir = "${var.local_cache_dir}"
 %{~else~}


### PR DESCRIPTION
See error:
Job's log exceeded limit of 4194304 bytes.
Job execution will continue but no more output will be collected.